### PR TITLE
Update sim status sync logic

### DIFF
--- a/usp_Telegence_Update_Device_updated.md
+++ b/usp_Telegence_Update_Device_updated.md
@@ -1,11 +1,13 @@
--- =============================================
--- Author:  Lee Daniel (Updated by automation)
--- Create date: 2019-10-28
---
--- Description: Updates TelegenceDevice based on the data in TelegenceDeviceStaging.
---              Updated to remove 3-sync hold, add feed-validity guard, and set
---              devices missing from a valid feed to Unknown immediately.
--- =============================================
+### Updated Stored Procedure: usp_Telegence_Update_Device
+
+The following SQL alters the procedure to:
+- Validate feed completeness and skip updates on invalid runs
+- Upsert device rows from staging, updating raw/effective statuses and last-seen timestamps
+- Immediately set devices not in the valid feed to `Unknown` with reason `NOT_FOUND_IN_FEED`
+- Remove the previous 3-sync hold logic
+- Provide a feature flag to toggle the immediate-unknown behavior
+
+```sql
 CREATE OR ALTER PROCEDURE [dbo].[usp_Telegence_Update_Device]
     @ServiceProviderId INT
 AS
@@ -221,3 +223,4 @@ BEGIN
 
     COMMIT TRANSACTION;
 END
+```


### PR DESCRIPTION
Update `usp_Telegence_Update_Device` to immediately set missing SIMs to `Unknown` and guard against incomplete carrier feeds, resolving status discrepancies.

The previous logic held a device's status for 3 syncs even if it disappeared from the carrier feed, leading to discrepancies where AMOP showed 'Active' while the carrier reported 'Unknown'. This change ensures AMOP reflects the carrier's truth immediately and prevents erroneous mass status changes from bad data feeds.

---
<a href="https://cursor.com/background-agent?bcId=bc-f54ee25b-accb-4f0a-853b-71e3751c9a90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f54ee25b-accb-4f0a-853b-71e3751c9a90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

